### PR TITLE
Update dependencies + drop requirement for nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,24 +23,20 @@ keywords = ["defmt", "embedded", "logging", "usb"]
 version = "*"
 
 [dependencies.defmt]
-version = "=0.3.0"
+version = "0.3.0"
 
 [dependencies.embassy-futures]
 version = "0.1.0"
-git = "https://github.com/embassy-rs/embassy"
 
 [dependencies.embassy-time]
-version = "0.1.0"
+version = "0.4.0"
 features = ["defmt", "defmt-timestamp-uptime"]
-git = "https://github.com/embassy-rs/embassy"
 
 [dependencies.embassy-usb]
-version = "0.1.0"
-git = "https://github.com/embassy-rs/embassy"
+version = "0.4.0"
 
 [dependencies.static_cell]
-version = "^1.2"
-features = ["nightly"]
+version = "2"
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,6 @@
 
 
 
-#![feature(type_alias_impl_trait)]
-
-
-
 mod buffer;
 mod controller;
 mod task;


### PR DESCRIPTION
Hi there! Thanks for this great crate. I've just started using it for my project, and had to make a few changes to get it to run with recent versions of dependencies:

- Update `embassy-usb` and `embassy-time` to `0.4.0`
- Update `static_cell` to `2`
- Drop specific requirement for `defmt`
- Download crates from crates.io, instead of github

As a bonus, I've removed the `type_alias_impl_trait` feature which allows me to stay on stable Rust. The code continues to compile, and work afterwards.

P.S.: Do you have any plans to upload this crate to `crates.io`? That would make it easier to consume. Happy to help.